### PR TITLE
Ignore comments

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,11 @@
+# This is the application port
 PORT=9000
+
+# App name
 APP_NAME=app
+# The environment
+# It may be "local"
+# Or "production"
 APP_ENV="local"
 APP_KEY=base-64:0
 APP_DEBUG=true

--- a/src/dot_env/internal/parser.gleam
+++ b/src/dot_env/internal/parser.gleam
@@ -116,7 +116,14 @@ fn lines_to_list(text: String) -> List(String) {
     Ok(re) -> regex.split(with: re, content: text)
     Error(_) -> []
   }
-  |> list.filter(fn(line) { line != "\n" })
+  |> list.filter(fn(line) { line != "\n" && !is_comment(line) })
+}
+
+fn is_comment(line: String) -> Bool {
+  case string.trim(line) {
+    "#" <> _ -> True
+    _ -> False
+  }
 }
 
 // replace parts of string with a regex - the standard library doesn't have this yet


### PR DESCRIPTION
When the `.env` file has comments in sequence:
```
# Like
# This
```

It can't parse the file. [Check this issue](https://github.com/Massolari/reddit_to_telegram/issues/4#issuecomment-2031854191)

This PR ignores the lines with comments.

I added some comments to the `.env` file so this case is now covered