### PR TITLE
Set error message in erlang ffi

### DIFF
--- a/src/dot_env_ffi.erl
+++ b/src/dot_env_ffi.erl
@@ -5,7 +5,7 @@
 get_env(Name) ->
   case os:getenv(binary_to_list(Name)) of
     false ->
-      {error, nil};
+      {error, list_to_binary(io_lib:format("key ~s is not set", [Name]))};
     Value ->
       {ok, list_to_binary(Value)}
   end.

--- a/test/dot_env_test.gleam
+++ b/test/dot_env_test.gleam
@@ -159,6 +159,9 @@ pub fn load_normal_test() {
 
   env.get("SPACED_KEY")
   |> should.equal(Ok("parsed"))
+
+  env.get("DOESNT_EXIST")
+  |> should.equal(Error("key DOESNT_EXIST is not set"))
 }
 
 pub fn load_multiline_test() {


### PR DESCRIPTION
The type of `env.get` is `Result(String, String)` but the erlang ffi does not return a string. So I added the same error message the js ffi returns to the erlang ffi. I'm not too familiar with erlang so it might not be as concise as it could be. It would be great if this could get merged, thanks in advance!