### PR TITLE
Relax `gleam_stdlib` version specification

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -10,7 +10,7 @@ internal_modules = ["dot_env/internal/*"]
 gleam = ">= 1.0.0"
 
 [dependencies]
-gleam_stdlib = ">= 0.40.0 and < 1.0.0"
+gleam_stdlib = ">= 0.40.0 and < 2.0.0"
 simplifile = ">= 2.1.0 and < 3.0.0"
 
 [dev-dependencies]

--- a/manifest.toml
+++ b/manifest.toml
@@ -9,6 +9,6 @@ packages = [
 ]
 
 [requirements]
-gleam_stdlib = { version = ">= 0.40.0 and < 1.0.0" }
+gleam_stdlib = { version = ">= 0.40.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.1.2 and < 2.0.0" }
 simplifile = { version = ">= 2.1.0 and < 3.0.0" }


### PR DESCRIPTION
This is to make `dot_env` work within projects using `gleam_stdlib >= 1.0.0`.